### PR TITLE
use nbformat to read/write

### DIFF
--- a/parse_yaml.py
+++ b/parse_yaml.py
@@ -1,33 +1,25 @@
-
-
-import json 
 import argparse
-
+import nbformat
 
 def format_notebook(filename:str)->int:
     keys = ["outputs_hidden", "source_hidden"]
     retv = 0
     with open(filename, 'r') as f:
-        data = json.load(f)
-        for cell in data["cells"]:
-            metadata = cell["metadata"]
-            for key in keys:
-                if "tags" in metadata.keys():
-                    if key in metadata["tags"]:
-                        if "jupyter" in metadata.keys():
-                            if key in metadata["jupyter"].keys():
-                                if metadata["jupyter"][key] == False: 
-                                    metadata["jupyter"][key] = True 
-                                    retv = 1
-                            else:
-                                metadata["jupyter"][key] = True
-                                retv = 1
-                        else:
-                            metadata["jupyter"] = {key: True}
-                            retv = 1
+        nb = nbformat.read(f, as_version=nbformat.NO_CONVERT)
+
+    for cell in nb["cells"]:
+        metadata = cell["metadata"]
+        print(metadata)
+        for key in keys:
+            if key in metadata.get("tags", []):
+                jupyter_meta = metadata.setdefault("jupyter", {})
+                before = jupyter_meta.get(key, False)
+                if not before:
+                    jupyter_meta[key] = True
+                    retv = 1
     if retv == 1:
         with open(filename, 'w') as f:
-            json.dump(data, f)
+            nbformat.write(nb, f, version=nbformat.NO_CONVERT)
     return retv
 
 

--- a/test_notebook.ipynb
+++ b/test_notebook.ipynb
@@ -1,1 +1,103 @@
-{"cells": [{"cell_type": "code", "execution_count": 4, "metadata": {"tags": []}, "outputs": [], "source": ["import numpy"]}, {"cell_type": "markdown", "metadata": {"tags": []}, "source": ["# Source hidden below, click to expand"]}, {"cell_type": "code", "execution_count": 5, "metadata": {"tags": ["source_hidden"], "jupyter": {"source_hidden": true}}, "outputs": [], "source": ["a = numpy.arange(5)"]}, {"cell_type": "markdown", "metadata": {}, "source": ["# Output hidden below, click to expand"]}, {"cell_type": "code", "execution_count": 6, "metadata": {"tags": ["outputs_hidden"], "jupyter": {"outputs_hidden": true}}, "outputs": [{"name": "stdout", "output_type": "stream", "text": ["[0 1 2 3 4]\n"]}], "source": ["print(a)"]}, {"cell_type": "code", "execution_count": 7, "metadata": {"tags": []}, "outputs": [], "source": ["# New cell"]}], "metadata": {"kernelspec": {"display_name": "Python 3 (ipykernel)", "language": "python", "name": "python3"}, "language_info": {"codemirror_mode": {"name": "ipython", "version": 3}, "file_extension": ".py", "mimetype": "text/x-python", "name": "python", "nbconvert_exporter": "python", "pygments_lexer": "ipython3", "version": "3.10.8"}}, "nbformat": 4, "nbformat_minor": 4}
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "# Source hidden below, click to expand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
+    "tags": [
+     "source_hidden"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "a = numpy.arange(5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Output hidden below, click to expand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "jupyter": {
+     "outputs_hidden": true
+    },
+    "tags": [
+     "outputs_hidden"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 2 3 4]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# New cell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
avoids consistent serialization issues with simple JSON dumps

alternately: could copy [default JSON dumps flags](https://github.com/jupyter/nbformat/blob/633a433d13436247c5994f571911c74a1ec507d4/nbformat/v4/nbjson.py#L50-L53): `(sort_keys=True, indent=1, ensure_ascii=False)`, which would _mostly_ cover it.